### PR TITLE
Workaround for int-or-string format issues

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -12,6 +12,13 @@
   [ "$output" = "The document fixtures/valid.json is a valid Deployment" ]
 }
 
+@test "Pass when parsing a valid Kubernetes config file with int_to_string vars" {
+  run kubeval fixtures/int_or_string.yaml
+	[ "$status" -eq 0 ]
+  [ "${lines[0]}" = "---> spec.ports.0.targetPort is an integer, but might be an int_or_string property" ]
+  [ "${lines[1]}" = "The document fixtures/int_or_string.yaml is a valid Service" ]
+}
+
 @test "Fail when parsing an invalid Kubernetes config file" {
   run kubeval fixtures/invalid.yaml
 	[ "$status" -eq 1 ]

--- a/fixtures/int_or_string.yaml
+++ b/fixtures/int_or_string.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    task: monitoring
+    # For use as a Cluster add-on (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons)
+    # If you are NOT using this as an addon, you should comment out this line.
+    kubernetes.io/cluster-service: 'true'
+    kubernetes.io/name: Heapster
+  name: heapster
+  namespace: kube-system
+spec:
+  ports:
+  - port: 80
+    targetPort: 8082
+  selector:
+    k8s-app: heapster

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: bae7942ce953957f11533a8509b412e748b6a62c53c50c4bca884a8de82b9252
-updated: 2017-06-27T11:51:10.969300219+01:00
+hash: bd3ca1478601970dda9ea6443ec42794136ef0c1cd134bff4770f53fdcfd7275
+updated: 2017-07-01T16:46:21.659717301+01:00
 imports:
 - name: github.com/fatih/color
   version: 570b54cabe6b8eb0bc2dfce68d964677d63b5260
@@ -21,6 +21,8 @@ imports:
   version: e02fc20de94c78484cd5ffb007f8af96be030a45
 - name: github.com/xeipuuv/gojsonschema
   version: 0c8571ac0ce161a5feb57375a9cdf148c98c0f70
+- name: github.com/yalp/jsonpath
+  version: 31a79c7593bb93eb10b163650d4a3e6ca190e4dc
 - name: golang.org/x/sys
   version: e24f485414aeafb646f6fca458b0bf869c0880a1
   repo: https://go.googlesource.com/sys

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,3 +5,4 @@ import:
 - package: gopkg.in/yaml.v2
 - package: github.com/fatih/color
   version: ^1.5.0
+- package: github.com/yalp/jsonpath


### PR DESCRIPTION
Kubernetes happily expects integers to be passed to fields of type
string, if they have the format int-or-string. This means the schema is
valid (because the rules around format are hazy) but actually validating
a document against a schema will fail - correctly in my view.

The proper fix for this likely involves some discussions with api
machinery and even some spec wrangling. In the meantime I'm going to
work around it here.

This first pass is pretty blunt. It has the potential to pass some
invalid documents with a warning. With a more specific jsonpath query,
and some parsing based on the Field() it's probably possible to make
this more accurate.