### PR TITLE
Add test to demonstrate support for int-or-string

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -12,6 +12,12 @@
   [ "$output" = "The document fixtures/valid.json is a valid Deployment" ]
 }
 
+@test "Pass when parsing a valid Kubernetes config file with int_to_string vars" {
+  run kubeval fixtures/int_or_string.yaml
+	[ "$status" -eq 0 ]
+  [ "$output" = "The document fixtures/int_or_string.yaml is a valid Service" ]
+}
+
 @test "Fail when parsing an invalid Kubernetes config file" {
   run kubeval fixtures/invalid.yaml
 	[ "$status" -eq 1 ]
@@ -34,3 +40,4 @@
 	[ "$status" -eq 1 ]
   [ $(expr "$output" : "^Missing a kind key") -ne 0 ]
 }
+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -142,7 +142,7 @@ func validate(element string) bool {
 		normalisedVersion = "v" + normalisedVersion
 	}
 
-	schema := fmt.Sprintf("https://raw.githubusercontent.com/garethr/%s-json-schema/master/%s/%s.json", schemaType, normalisedVersion, strings.ToLower(kind))
+	schema := fmt.Sprintf("https://raw.githubusercontent.com/garethr/%s-json-schema/master/%s-standalone/%s.json", schemaType, normalisedVersion, strings.ToLower(kind))
 
 	schemaLoader := gojsonschema.NewReferenceLoader(schema)
 

--- a/fixtures/int_or_string.yaml
+++ b/fixtures/int_or_string.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    task: monitoring
+    # For use as a Cluster add-on (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons)
+    # If you are NOT using this as an addon, you should comment out this line.
+    kubernetes.io/cluster-service: 'true'
+    kubernetes.io/name: Heapster
+  name: heapster
+  namespace: kube-system
+spec:
+  ports:
+  - port: 80
+    targetPort: 8082
+  selector:
+    k8s-app: heapster


### PR DESCRIPTION
Most of the fix was in updating the schemas to swap int-or-string for
oneOf. I've only updated the standalone schemas so far so switching
kubeval to use those for the moment.