### PR TITLE
Ability to build/publish a docker image of kubeval

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+README.md
+Dockerfile
+LICENSE
+acceptance.bat
+bin
+fixtures
+releases
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.8-alpine as builder
+RUN apk --no-cache add make git
+RUN mkdir -p /go/src/github.com/garethr/kubeval/
+COPY . /go/src/github.com/garethr/kubeval/
+WORKDIR /go/src/github.com/garethr/kubeval/
+RUN make linux
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+COPY --from=builder /go/src/github.com/garethr/kubeval/bin/linux/amd64/kubeval .
+ENTRYPOINT ["/kubeval"]
+CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 NAME=kubeval
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
+TAG=$$(git describe --abbrev=0 --tags)
 
 all: build
 
@@ -50,6 +51,14 @@ windows: vendor releases bin/windows/amd64
 lint: $(GOPATH)/bin/golint
 	golint
 
+docker:
+	docker build -t garethr/kubeval:$(TAG) .
+	docker tag garethr/kubeval:$(TAG) garethr/kubeval:latest.
+
+publish: docker
+	docker push garethr/kubeval:$(TAG)
+	docker push garethr/kubeval:latest
+
 test:
 	go test
 
@@ -67,4 +76,4 @@ clean:
 fmt:
 	gofmt -w $(GOFMT_FILES)
 
-.PHONY: fmt clean cover acceptance test windows linux darwin build check
+.PHONY: fmt clean cover acceptance lint docker test windows linux darwin build check

--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ tar xf kubeval-darwin-amd64.tar.gz
 cp bin/darwin/amd64/kubeval /usr/local/bin
 ```
 
+`kubeval` is also published as a Docker image. So can be used as
+follows:
+
+```
+$ docker run -it -v `pwd`/fixtures:/fixtures garethr/kubeval fixtures/*
+Missing a kind key in /fixtures/blank.yaml
+The document fixtures/int_or_string.yaml is a valid Service
+The document fixtures/int_or_string_false.yaml is not a valid Deployment
+--> spec.template.spec.containers.0.env.0.value: Invalid type. Expected: string, given: integer
+The document fixtures/invalid.yaml is not a valid ReplicationController
+--> spec.replicas: Invalid type. Expected: integer, given: string
+Missing a kind key in /fixtures/missing-kind.yaml
+The document fixtures/valid.json is a valid Deployment
+The document fixtures/valid.yaml is a valid ReplicationController
+```
 
 ### From source
 


### PR DESCRIPTION
I've not used an automated build as Hub doesn't yet support multi-stage
builds, which makes the builder much simpler.