### PR TITLE
Start splitting kubeval up into separate packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-kubeval
 vendor
 bin
 releases

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,75 +1,15 @@
 package cmd
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/xeipuuv/gojsonschema"
-	"gopkg.in/yaml.v2"
+
+	"github.com/garethr/kubeval/kubeval"
+	"github.com/garethr/kubeval/log"
 )
-
-// Version represents the version of Kubernetes
-// for which we should load the schema
-var Version string
-
-// OpenShift represents whether to test against
-// upstream Kubernetes of the OpenShift schemas
-var OpenShift bool
-
-// ValidFormat is a type for quickly forcing
-// new formats on the gojsonschema loader
-type ValidFormat struct{}
-
-// IsFormat always retusn true and meets the
-// gojsonschema.FormatChecker interface
-func (f ValidFormat) IsFormat(input string) bool {
-	return true
-}
-
-func info(message ...interface{}) {
-	fmt.Println(message...)
-}
-
-func success(message ...interface{}) {
-	green := color.New(color.FgGreen)
-	green.Println(message...)
-}
-
-func warn(message ...interface{}) {
-	yellow := color.New(color.FgYellow)
-	yellow.Println(message...)
-}
-
-func error(message ...interface{}) {
-	red := color.New(color.FgRed)
-	red.Println(message...)
-}
-
-// Based on https://stackoverflow.com/questions/40737122/convert-yaml-to-json-without-struct-golang
-// We unmarshal yaml into a value of type interface{},
-// go through the result recursively, and convert each encountered
-// map[interface{}]interface{} to a map[string]interface{} value
-// required to marshall to JSON.
-func convertToStringKeys(i interface{}) interface{} {
-	switch x := i.(type) {
-	case map[interface{}]interface{}:
-		m2 := map[string]interface{}{}
-		for k, v := range x {
-			m2[k.(string)] = convertToStringKeys(v)
-		}
-		return m2
-	case []interface{}:
-		for i, v := range x {
-			x[i] = convertToStringKeys(v)
-		}
-	}
-	return i
-}
 
 // RootCmd represents the the command to run when kubeval is run
 var RootCmd = &cobra.Command{
@@ -78,12 +18,17 @@ var RootCmd = &cobra.Command{
 	Long:  `Validate a Kubernetes YAML file against the relevant schema`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			error("You must pass at least one file as an argument")
+			log.Error("You must pass at least one file as an argument")
 			os.Exit(1)
 		}
 		success := true
-		for _, file := range args {
-			valid := validate(file)
+		for _, fileName := range args {
+			filePath, _ := filepath.Abs(fileName)
+			yamlFile, err := ioutil.ReadFile(filePath)
+			if err != nil {
+				log.Error("Could not open file", fileName)
+			}
+			valid := kubeval.Validate(yamlFile, fileName)
 			if success {
 				success = valid
 			}
@@ -94,94 +39,16 @@ var RootCmd = &cobra.Command{
 	},
 }
 
-// Validate a Kubernetes YAML file according to a relevant schema
-// TODO This function requires a judicious amount of refactoring.
-func validate(element string) bool {
-	// Open the YAML file, convert to a Go interface and then
-	// load that as a document for gojsonschema to process
-	filename, _ := filepath.Abs(element)
-	yamlFile, err := ioutil.ReadFile(filename)
-	if err != nil {
-		error("Could not open file", filename)
-		return false
-	}
-
-	var spec interface{}
-	err = yaml.Unmarshal(yamlFile, &spec)
-	if err != nil {
-		error("Failed to decode YAML from", filename)
-		return false
-	}
-
-	body := convertToStringKeys(spec)
-
-	documentLoader := gojsonschema.NewGoLoader(body)
-
-	cast, _ := body.(map[string]interface{})
-	if _, ok := cast["kind"]; !ok {
-		error("Missing a kind key in", filename)
-		return false
-	}
-
-	kind := cast["kind"].(string)
-
-	// We have both the upstream Kubernetes schemas and the OpenShift schemas available
-	// the tool can toggle between then using the --openshift boolean flag and here we
-	// use that to select which repository to get the schema from
-	var schemaType string
-	if OpenShift {
-		schemaType = "openshift"
-	} else {
-		schemaType = "kubernetes"
-	}
-
-	// Most of the directories which store the schemas are prefixed with a v so as to
-	// match the tagging in the Kubernetes repository, apart from master.
-	normalisedVersion := Version
-	if Version != "master" {
-		normalisedVersion = "v" + normalisedVersion
-	}
-
-	schema := fmt.Sprintf("https://raw.githubusercontent.com/garethr/%s-json-schema/master/%s-standalone/%s.json", schemaType, normalisedVersion, strings.ToLower(kind))
-
-	schemaLoader := gojsonschema.NewReferenceLoader(schema)
-
-	// Without forcing these types the schema fails to load
-	// Need to Work out proper handling for these types
-	gojsonschema.FormatCheckers.Add("int64", ValidFormat{})
-	gojsonschema.FormatCheckers.Add("byte", ValidFormat{})
-	gojsonschema.FormatCheckers.Add("int32", ValidFormat{})
-	gojsonschema.FormatCheckers.Add("int-or-string", ValidFormat{})
-
-	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
-	if err != nil {
-		error("Problem loading schema from the network")
-		info(err)
-		return false
-	}
-
-	if result.Valid() {
-		success("The document", element, "is a valid", kind)
-		return true
-	}
-
-	warn("The document", element, "is not a valid", kind)
-	for _, desc := range result.Errors() {
-		info("-->", desc)
-	}
-	return false
-}
-
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		error(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 }
 
 func init() {
-	RootCmd.Flags().StringVarP(&Version, "kubernetes-version", "v", "master", "Version of Kubernetes to validate against")
-	RootCmd.Flags().BoolVarP(&OpenShift, "openshift", "", false, "Use OpenShift schemas instead of upstream Kubernetes")
+	RootCmd.Flags().StringVarP(&kubeval.Version, "kubernetes-version", "v", "master", "Version of Kubernetes to validate against")
+	RootCmd.Flags().BoolVarP(&kubeval.OpenShift, "openshift", "", false, "Use OpenShift schemas instead of upstream Kubernetes")
 }

--- a/kubeval/kubeval.go
+++ b/kubeval/kubeval.go
@@ -1,0 +1,98 @@
+package kubeval
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/xeipuuv/gojsonschema"
+	"gopkg.in/yaml.v2"
+
+	"github.com/garethr/kubeval/log"
+)
+
+// Version represents the version of Kubernetes
+// for which we should load the schema
+var Version string
+
+// OpenShift represents whether to test against
+// upstream Kubernetes of the OpenShift schemas
+var OpenShift bool
+
+// ValidFormat is a type for quickly forcing
+// new formats on the gojsonschema loader
+type ValidFormat struct{}
+
+// IsFormat always retusn true and meets the
+// gojsonschema.FormatChecker interface
+func (f ValidFormat) IsFormat(input string) bool {
+	return true
+}
+
+// Validate a Kubernetes YAML file according to a relevant schema
+// TODO This function requires a judicious amount of refactoring.
+func Validate(element []byte, fileName string) bool {
+	var spec interface{}
+	err := yaml.Unmarshal(element, &spec)
+	if err != nil {
+		log.Error("Failed to decode YAML from", fileName)
+		return false
+	}
+
+	body := convertToStringKeys(spec)
+
+	documentLoader := gojsonschema.NewGoLoader(body)
+
+	cast, _ := body.(map[string]interface{})
+	if _, ok := cast["kind"]; !ok {
+		log.Error("Missing a kind key in", fileName)
+		return false
+	}
+
+	kind := cast["kind"].(string)
+
+	// We have both the upstream Kubernetes schemas and the OpenShift schemas available
+	// the tool can toggle between then using the --openshift boolean flag and here we
+	// use that to select which repository to get the schema from
+	var schemaType string
+	if OpenShift {
+		schemaType = "openshift"
+	} else {
+		schemaType = "kubernetes"
+	}
+
+	// Most of the directories which store the schemas are prefixed with a v so as to
+	// match the tagging in the Kubernetes repository, apart from master.
+	normalisedVersion := Version
+	if Version != "master" {
+		normalisedVersion = "v" + normalisedVersion
+	}
+
+	schema := fmt.Sprintf("https://raw.githubusercontent.com/garethr/%s-json-schema/master/%s-standalone/%s.json", schemaType, normalisedVersion, strings.ToLower(kind))
+
+	schemaLoader := gojsonschema.NewReferenceLoader(schema)
+
+	// Without forcing these types the schema fails to load
+	// Need to Work out proper handling for these types
+	gojsonschema.FormatCheckers.Add("int64", ValidFormat{})
+	gojsonschema.FormatCheckers.Add("byte", ValidFormat{})
+	gojsonschema.FormatCheckers.Add("int32", ValidFormat{})
+	gojsonschema.FormatCheckers.Add("int-or-string", ValidFormat{})
+
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
+		log.Error("Problem loading schema from the network")
+		log.Info(err)
+		return false
+	}
+
+	if result.Valid() {
+		log.Success("The document", fileName, "is a valid", kind)
+		return true
+	}
+
+	log.Warn("The document", fileName, "is not a valid", kind)
+	for _, desc := range result.Errors() {
+		log.Info("-->", desc)
+	}
+	return false
+}

--- a/kubeval/utils.go
+++ b/kubeval/utils.go
@@ -1,0 +1,22 @@
+package kubeval
+
+// Based on https://stackoverflow.com/questions/40737122/convert-yaml-to-json-without-struct-golang
+// We unmarshal yaml into a value of type interface{},
+// go through the result recursively, and convert each encountered
+// map[interface{}]interface{} to a map[string]interface{} value
+// required to marshall to JSON.
+func convertToStringKeys(i interface{}) interface{} {
+	switch x := i.(type) {
+	case map[interface{}]interface{}:
+		m2 := map[string]interface{}{}
+		for k, v := range x {
+			m2[k.(string)] = convertToStringKeys(v)
+		}
+		return m2
+	case []interface{}:
+		for i, v := range x {
+			x[i] = convertToStringKeys(v)
+		}
+	}
+	return i
+}

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,26 @@
+package log
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+func Info(message ...interface{}) {
+	fmt.Println(message...)
+}
+
+func Success(message ...interface{}) {
+	green := color.New(color.FgGreen)
+	green.Println(message...)
+}
+
+func Warn(message ...interface{}) {
+	yellow := color.New(color.FgYellow)
+	yellow.Println(message...)
+}
+
+func Error(message ...interface{}) {
+	red := color.New(color.FgRed)
+	red.Println(message...)
+}


### PR DESCRIPTION
First pass at splitting the monolithic package into separate packages.
This also facilitates the use of kubeval as a library by other tools
which has been discussed a few times.

This is the first pass at this, I want to split the Validate function
down some, and make sure everything is documented. I'll get this merged
quickly to avoid any pain with PRs needing rebasing.