### PR TITLE
Kubeval can now print it's own version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 NAME=kubeval
+PACKAGE_NAME=github.com/garethr/$(NAME)
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 TAG=$$(git describe --abbrev=0 --tags)
+
+LDFLAGS += -X "$(PACKAGE_NAME)/version.BuildTime=$(shell date -u '+%Y-%m-%d %I:%M:%S %Z')"
+LDFLAGS += -X "$(PACKAGE_NAME)/version.BuildVersion=$(shell git describe --abbrev=0 --tags)"
+LDFLAGS += -X "$(PACKAGE_NAME)/version.BuildSHA=$(shell git rev-parse HEAD)"
+# Strip debug information
+LDFLAGS += -s
 
 all: build
 
@@ -37,15 +44,15 @@ bin/darwin/amd64:
 build: darwin linux windows
 
 darwin: vendor releases bin/darwin/amd64
-	env GOOS=darwin GOAARCH=amd64 go build -v -o $(CURDIR)/bin/darwin/amd64/$(NAME)
+	env GOOS=darwin GOAARCH=amd64 go build -ldflags '$(LDFLAGS)' -v -o $(CURDIR)/bin/darwin/amd64/$(NAME)
 	tar -cvzf releases/$(NAME)-darwin-amd64.tar.gz bin/darwin/amd64/$(NAME)
 
 linux: vendor releases bin/linux/amd64
-	env GOOS=linux GOAARCH=amd64 go build -v -o $(CURDIR)/bin/linux/amd64/$(NAME)
+	env GOOS=linux GOAARCH=amd64 go build -ldflags '$(LDFLAGS)' -v -o $(CURDIR)/bin/linux/amd64/$(NAME)
 	tar -cvzf releases/$(NAME)-linux-amd64.tar.gz bin/linux/amd64/$(NAME)
 
 windows: vendor releases bin/windows/amd64
-	env GOOS=windows GOAARCH=amd64 go build -v -o $(CURDIR)/bin/windows/amd64/$(NAME)
+	env GOOS=windows GOAARCH=amd64 go build -ldflags '$(LDFLAGS)' -v -o $(CURDIR)/bin/windows/amd64/$(NAME)
 	tar -cvzf releases/$(NAME)-windows-amd64.tar.gz bin/windows/amd64/$(NAME)
 
 lint: $(GOPATH)/bin/golint

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,10 @@ var RootCmd = &cobra.Command{
 	Short: "Validate a Kubernetes YAML file against the relevant schema",
 	Long:  `Validate a Kubernetes YAML file against the relevant schema`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if Version {
+			printVersion()
+			os.Exit(0)
+		}
 		if len(args) < 1 {
 			log.Error("You must pass at least one file as an argument")
 			os.Exit(1)
@@ -52,4 +56,5 @@ func Execute() {
 func init() {
 	RootCmd.Flags().StringVarP(&kubeval.Version, "kubernetes-version", "v", "master", "Version of Kubernetes to validate against")
 	RootCmd.Flags().BoolVarP(&kubeval.OpenShift, "openshift", "", false, "Use OpenShift schemas instead of upstream Kubernetes")
+	RootCmd.Flags().BoolVarP(&Version, "version", "", false, "Display the kubeval version information and exit")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/garethr/kubeval/version"
+)
+
+var Version bool
+
+var versionTemplate = `Version:      {{.BuildVersion}}
+Git commit:   {{.BuildSHA}}
+Built:        {{.BuildTime}}
+Go version:   {{.GoVersion}}
+OS/Arch:      {{.Os}}/{{.Arch}}`
+
+func printVersion() {
+	renderedVersionOutput, _ := renderVersionTemplate()
+	fmt.Println(renderedVersionOutput)
+}
+
+func renderVersionTemplate() (string, error) {
+	versionTemplate, err := template.New("version").Parse(versionTemplate)
+	if err != nil {
+		return "", err
+	}
+	var versionOutputBuffer bytes.Buffer
+	err = versionTemplate.Execute(&versionOutputBuffer, version.Version)
+	if err != nil {
+		return "", err
+	}
+	return versionOutputBuffer.String(), nil
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,32 @@
+package version
+
+import (
+	"runtime"
+)
+
+var (
+	// BuildVersion set at build time
+	BuildVersion string
+	// BuildTime set at build time
+	BuildTime string
+	// BuildSHA set at build time
+	BuildSHA string
+)
+
+// ClientVersion contains information about the current client
+type ClientVersion struct {
+	BuildVersion string
+	BuildTime    string
+	BuildSHA     string
+	GoVersion    string
+	Os           string
+	Arch         string
+}
+
+// Version constructed at build time
+var Version = ClientVersion{BuildVersion,
+	BuildTime,
+	BuildSHA,
+	runtime.Version(),
+	runtime.GOOS,
+	runtime.GOARCH}


### PR DESCRIPTION
Passing --version will print build information, including the git sha,
tag, architecture/OS details and Go version

Resolves #12 