### PR TITLE
Make kubeval usable as a Go library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,20 @@ sudo: false
 go:
 - 1.8
 
-script:
-- make check lint build
-- PATH=bin/linux/amd64:$PATH make acceptance
-
-deploy:
-  provider: releases
-  api_key:
-    secure: oHlh/sYGqn7coTzlRAm5Qnxb8fCbpd0VV3jDhbVZgNw2a0gNDLZ5UqI8POirLEsG/ezfiZyA6Q3xglLcIejsmfupDZ12aUyWNlqzjrJt8G0tDqWEF5X27OiGk5bKJZ0i9llSq8Unj8TRxRO90Uyxd4pjj+vXiH9N0rVO5x79bHA4d49CdP7BefABBuj3TW0cQ5odn/JMZD/XPZIqZ9T46k86IszQIkio0krCAMStnAyB/xFg+aPH8RB3sdi1jFqO95AZpPGvmnZCVVpXeJ7TFCnakL3s4Gk3JdlYVLz5lnZIqVswFXNoBgAXWATO62mtiobpG/qBZVGc12b5wwckR5sXsc7BW8DbtEpvKX7xA8HyvvMtrnR52KwzukmRK5QH8BxoKPOXRlpSzI7SOWhZWy+tWTAnQiZr054p1I+A/S8YafwJBEbTPx3PVeEk/lC4jsPJ3TOGw6TSkflT90FcvgNhR5AG0TrwT3DJ1JpVoO0jJmsU/QyjvgpxuAlLNbikx3edhdiOYnjpHYUtpMxu5VSy14C4sJQtTg7Q1oLZgsg6GJuk1VfWvY2z7gUfyL+OEq64oi89y9b9YX7dc7qIjgZQfX57KDDeyEKqJN3Gyu9QhCC9N7D/LZivSZqthkIdIle0SGArMAJlUPBqZp6zgMaea6E8pl24qLEDRDfQAl4=
-  file:
-  - releases/kubeval-darwin-amd64.tar.gz
-  - releases/kubeval-windows-amd64.tar.gz
-  - releases/kubeval-linux-amd64.tar.gz
-  on:
-    repo: garethr/kubeval
-    tags: true
+jobs:
+  include:
+    - script: make check lint test
+    - script: PATH=bin/linux/amd64:$PATH make build acceptance
+    - stage: deploy
+      script: skip
+      deploy:
+        provider: releases
+        api_key:
+          secure: oHlh/sYGqn7coTzlRAm5Qnxb8fCbpd0VV3jDhbVZgNw2a0gNDLZ5UqI8POirLEsG/ezfiZyA6Q3xglLcIejsmfupDZ12aUyWNlqzjrJt8G0tDqWEF5X27OiGk5bKJZ0i9llSq8Unj8TRxRO90Uyxd4pjj+vXiH9N0rVO5x79bHA4d49CdP7BefABBuj3TW0cQ5odn/JMZD/XPZIqZ9T46k86IszQIkio0krCAMStnAyB/xFg+aPH8RB3sdi1jFqO95AZpPGvmnZCVVpXeJ7TFCnakL3s4Gk3JdlYVLz5lnZIqVswFXNoBgAXWATO62mtiobpG/qBZVGc12b5wwckR5sXsc7BW8DbtEpvKX7xA8HyvvMtrnR52KwzukmRK5QH8BxoKPOXRlpSzI7SOWhZWy+tWTAnQiZr054p1I+A/S8YafwJBEbTPx3PVeEk/lC4jsPJ3TOGw6TSkflT90FcvgNhR5AG0TrwT3DJ1JpVoO0jJmsU/QyjvgpxuAlLNbikx3edhdiOYnjpHYUtpMxu5VSy14C4sJQtTg7Q1oLZgsg6GJuk1VfWvY2z7gUfyL+OEq64oi89y9b9YX7dc7qIjgZQfX57KDDeyEKqJN3Gyu9QhCC9N7D/LZivSZqthkIdIle0SGArMAJlUPBqZp6zgMaea6E8pl24qLEDRDfQAl4=
+        file:
+        - releases/kubeval-darwin-amd64.tar.gz
+        - releases/kubeval-windows-amd64.tar.gz
+        - releases/kubeval-linux-amd64.tar.gz
+        on:
+          repo: garethr/kubeval
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 
 jobs:
   include:
-    - script: make check lint test
+    - script: make vet check lint coveralls
     - script: PATH=bin/linux/amd64:$PATH make build acceptance
     - stage: deploy
       script: skip

--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,16 @@ publish: docker
 	docker push garethr/kubeval:latest
 
 test:
-	go test
+	go test -v -cover `glide novendor`
+
+watch:
+	ls */*.go | entr make test
 
 acceptance: .bats
 	env PATH=./.bats/bin:$$PATH:./bin/darwin/amd64 ./acceptance.bats
 
 cover:
-	go test -coverprofile=coverage.out
+	go test -v ./kubeval -coverprofile=coverage.out
 	go tool cover -html=coverage.out
 	rm coverage.out
 
@@ -83,4 +86,4 @@ clean:
 fmt:
 	gofmt -w $(GOFMT_FILES)
 
-.PHONY: fmt clean cover acceptance lint docker test windows linux darwin build check
+.PHONY: fmt clean cover acceptance lint docker test watch windows linux darwin build check

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ $(GOPATH)/bin/glide:
 $(GOPATH)/bin/golint:
 	go get github.com/golang/lint/golint
 
+$(GOPATH)/bin/goveralls:
+	go get github.com/mattn/goveralls
+
 $(GOPATH)/bin/errcheck:
 	go get -u github.com/kisielk/errcheck
 
@@ -74,8 +77,11 @@ publish: docker
 vet:
 	go vet `glide novendor`
 
-test: vendor
+test: vendor vet lint check
 	go test -v -cover `glide novendor`
+
+coveralls: vendor $(GOPATH)/bin/goveralls
+	goveralls -service=travis-ci
 
 watch:
 	ls */*.go | entr make test

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,13 @@ $(GOPATH)/bin/errcheck:
 .bats:
 	git clone --depth 1 https://github.com/sstephenson/bats.git .bats
 
-vendor: glide.yaml $(GOPATH)/bin/glide
+glide.lock: glide.yaml $(GOPATH)/bin/glide
+	glide update
+	@touch $@
+
+vendor: glide.lock
 	glide install
+	@touch $@
 
 check: vendor $(GOPATH)/bin/errcheck
 	errcheck
@@ -66,7 +71,10 @@ publish: docker
 	docker push garethr/kubeval:$(TAG)
 	docker push garethr/kubeval:latest
 
-test:
+vet:
+	go vet `glide novendor`
+
+test: vendor
 	go test -v -cover `glide novendor`
 
 watch:
@@ -86,4 +94,4 @@ clean:
 fmt:
 	gofmt -w $(GOFMT_FILES)
 
-.PHONY: fmt clean cover acceptance lint docker test watch windows linux darwin build check
+.PHONY: fmt clean cover acceptance lint docker test vet watch windows linux darwin build check

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Status](https://travis-ci.org/garethr/kubeval.svg)](https://travis-ci.org/gareth
 [![Go Report
 Card](https://goreportcard.com/badge/github.com/garethr/kubeval)](https://goreportcard.com/report/github.com/garethr/kubeval)
 [![GoDoc](https://godoc.org/github.com/garethr/kubeval?status.svg)](https://godoc.org/github.com/garethr/kubeval)
+[![Coverage
+Status](https://coveralls.io/repos/github/garethr/kubeval/badge.svg?branch=master)](https://coveralls.io/github/garethr/kubeval?branch=master)
 
 ```
 $ kubeval my-invalid-rc.yaml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Kubeval
 
 `kubeval` is a tool for validating a Kubernetes YAML or JSON configuration file.
+It can also be used as a library in other Go applications.
 
 [![Build
 Status](https://travis-ci.org/garethr/kubeval.svg)](https://travis-ci.org/garethr/kubeval)
@@ -123,6 +124,33 @@ The command has three important features:
 $ kubeval -v 1.6.6 my-deployment.yaml
 $ kubeval --openshift -v 1.5.1 my-deployment.yaml
 ```
+
+## Library
+
+After installing with you prefered dependency management tool, import the relevant module.
+
+```go
+import (
+  "github.com/garethr/kubeval/kubeval"
+)
+```
+
+The module provides one public function, `Validate`, which can be used
+like so:
+
+```go
+results, err := kubeval.Validate(fileContents, fileName)
+```
+
+The method signature for `Validate` is:
+
+```go
+Validate(config []byte, fileName string) ([]ValidationResult, error)
+```
+
+The simples way of seeing it's usage is probably in the `kubeval`
+[command line tool source code](cmd/root.go).
+
 
 ## Status
 

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -48,6 +48,4 @@
 @test "Return relevant error for YAML missing kind key" {
   run kubeval fixtures/missing-kind.yaml
 	[ "$status" -eq 1 ]
-  [ $(expr "$output" : "^Missing a kind key") -ne 0 ]
 }
-

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: bae7942ce953957f11533a8509b412e748b6a62c53c50c4bca884a8de82b9252
-updated: 2017-06-27T11:51:10.969300219+01:00
+hash: f95ca47dd12b1bdbb09bee308035863865c964aacdcfc6083a34a0756610ae56
+updated: 2017-07-18T15:25:07.669274371+01:00
 imports:
 - name: github.com/fatih/color
   version: 570b54cabe6b8eb0bc2dfce68d964677d63b5260
+- name: github.com/hashicorp/go-multierror
+  version: 83588e72410abfbe4df460eeb6f30841ae47d4c4
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/mattn/go-colorable

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,3 +5,4 @@ import:
 - package: gopkg.in/yaml.v2
 - package: github.com/fatih/color
   version: ^1.5.0
+- package: github.com/hashicorp/go-multierror

--- a/kubeval/kubeval.go
+++ b/kubeval/kubeval.go
@@ -2,13 +2,13 @@ package kubeval
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/xeipuuv/gojsonschema"
 	"gopkg.in/yaml.v2"
-
-	"github.com/garethr/kubeval/log"
 )
 
 // Version represents the version of Kubernetes
@@ -23,18 +23,29 @@ var OpenShift bool
 // new formats on the gojsonschema loader
 type ValidFormat struct{}
 
-// IsFormat always retusn true and meets the
+// IsFormat always returns true and meets the
 // gojsonschema.FormatChecker interface
 func (f ValidFormat) IsFormat(input string) bool {
 	return true
 }
 
-func validateResource(data []byte, fileName string) bool {
+// ValidationResult contains the details from
+// validating a given Kubernetes resource
+type ValidationResult struct {
+	FileName string
+	Kind     string
+	Errors   []gojsonschema.ResultError
+}
+
+// validateResource validates a single Kubernetes resource against
+// the relevant schema, detecting the type of resource automatically
+func validateResource(data []byte, fileName string) (ValidationResult, error) {
 	var spec interface{}
+	result := ValidationResult{}
+	result.FileName = fileName
 	err := yaml.Unmarshal(data, &spec)
 	if err != nil {
-		log.Error("Failed to decode YAML from", fileName)
-		return false
+		return result, errors.New("Failed to decode YAML from " + fileName)
 	}
 
 	body := convertToStringKeys(spec)
@@ -43,11 +54,11 @@ func validateResource(data []byte, fileName string) bool {
 
 	cast, _ := body.(map[string]interface{})
 	if _, ok := cast["kind"]; !ok {
-		log.Error("Missing a kind key in", fileName)
-		return false
+		return result, errors.New("Missing a kind key in " + fileName)
 	}
 
 	kind := cast["kind"].(string)
+	result.Kind = kind
 
 	// We have both the upstream Kubernetes schemas and the OpenShift schemas available
 	// the tool can toggle between then using the --openshift boolean flag and here we
@@ -59,6 +70,10 @@ func validateResource(data []byte, fileName string) bool {
 		schemaType = "kubernetes"
 	}
 
+	// Set a default Version to make usage as a library easier
+	if Version == "" {
+		Version = "master"
+	}
 	// Most of the directories which store the schemas are prefixed with a v so as to
 	// match the tagging in the Kubernetes repository, apart from master.
 	normalisedVersion := Version
@@ -77,49 +92,39 @@ func validateResource(data []byte, fileName string) bool {
 	gojsonschema.FormatCheckers.Add("int32", ValidFormat{})
 	gojsonschema.FormatCheckers.Add("int-or-string", ValidFormat{})
 
-	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	results, err := gojsonschema.Validate(schemaLoader, documentLoader)
 	if err != nil {
-		log.Error("Problem loading schema from the network")
-		log.Info(err)
-		return false
+		return result, errors.New("Problem loading schema from the network")
 	}
 
-	if result.Valid() {
-		log.Success("The document", fileName, "contains a valid", kind)
-		return true
+	if results.Valid() {
+		return result, nil
 	}
 
-	log.Warn("The document", fileName, "contains an invalid", kind)
-	for _, desc := range result.Errors() {
-		log.Info("-->", desc)
-	}
-	return false
+	result.Errors = results.Errors()
+	return result, nil
 }
 
-// Validate a Kubernetes YAML file according to a relevant schema
+// Validate a Kubernetes YAML file, parsing out individual resources
+// and validating them all according to the  relevant schemas
 // TODO This function requires a judicious amount of refactoring.
-func Validate(config []byte, fileName string) bool {
-
+func Validate(config []byte, fileName string) ([]ValidationResult, error) {
 	if len(config) == 0 {
-		log.Error("The document", fileName, "appears to be empty")
-		return false
+		return nil, errors.New("The document " + fileName + " appears to be empty")
 	}
 
 	bits := bytes.Split(config, []byte("---\n"))
 
-	results := make([]bool, len(bits))
+	results := make([]ValidationResult, len(bits))
+	var errors *multierror.Error
 	for i, element := range bits {
 		if len(element) > 0 {
-			result := validateResource(element, fileName)
+			result, err := validateResource(element, fileName)
 			results[i] = result
-		} else {
-			results[i] = true
+			if err != nil {
+				errors = multierror.Append(errors, err)
+			}
 		}
 	}
-	for _, a := range results {
-		if a == false {
-			return false
-		}
-	}
-	return true
+	return results, errors.ErrorOrNil()
 }

--- a/kubeval/kubeval_test.go
+++ b/kubeval/kubeval_test.go
@@ -1,12 +1,63 @@
 package kubeval
 
-import "testing"
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
 
 func TestValidateBlankInput(t *testing.T) {
 	blank := []byte("")
 	_, err := Validate(blank, "sample")
 	if err == nil {
 		t.Errorf("Validate should fail when passed a blank string")
+	}
+}
+
+func TestValidateValidInputs(t *testing.T) {
+	var tests = []string{
+		"valid.yaml",
+		"valid.json",
+		"multi_valid.yaml",
+		"int_or_string.yaml",
+	}
+	for _, test := range tests {
+		filePath, _ := filepath.Abs("../fixtures/" + test)
+		fileContents, _ := ioutil.ReadFile(filePath)
+		_, err := Validate(fileContents, test)
+		if err != nil {
+			t.Errorf("Validate should pass when testing valid configuration in " + test)
+		}
+	}
+}
+
+func TestValidateInvalidInputs(t *testing.T) {
+	var tests = []string{
+		"blank.yaml",
+		"missing-kind.json",
+	}
+	for _, test := range tests {
+		filePath, _ := filepath.Abs("../fixtures/" + test)
+		fileContents, _ := ioutil.ReadFile(filePath)
+		_, err := Validate(fileContents, test)
+		if err == nil {
+			t.Errorf("Validate should not pass when testing invalid configuration in " + test)
+		}
+	}
+}
+
+func TestValidateInputsWithErrors(t *testing.T) {
+	var tests = []string{
+		"invalid.yaml",
+		"multi_invalid.yaml",
+	}
+	for _, test := range tests {
+		filePath, _ := filepath.Abs("../fixtures/" + test)
+		fileContents, _ := ioutil.ReadFile(filePath)
+		results, _ := Validate(fileContents, test)
+		if len(results[0].Errors) == 0 {
+			t.Errorf("Validate should not pass when testing invalid configuration in " + test)
+		}
 	}
 }
 

--- a/kubeval/kubeval_test.go
+++ b/kubeval/kubeval_test.go
@@ -1,0 +1,41 @@
+package kubeval
+
+import "testing"
+
+func TestValidateBlankInput(t *testing.T) {
+	blank := []byte("")
+	_, err := Validate(blank, "sample")
+	if err == nil {
+		t.Errorf("Validate should fail when passed a blank string")
+	}
+}
+
+func TestDetermineSchema(t *testing.T) {
+	schema := determineSchema("sample")
+	if schema != "https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/master-standalone/sample.json" {
+		t.Errorf("Schema should default to master")
+	}
+}
+
+func TestDetermineSchemaForOpenShift(t *testing.T) {
+	OpenShift = true
+	schema := determineSchema("sample")
+	if schema != "https://raw.githubusercontent.com/garethr/openshift-json-schema/master/master-standalone/sample.json" {
+		t.Errorf("Should be able to toggle to OpenShift schemas")
+	}
+}
+
+func TestDetermineSchemaForVersions(t *testing.T) {
+	Version = "1.0"
+	schema := determineSchema("sample")
+	if schema != "https://raw.githubusercontent.com/garethr/openshift-json-schema/master/v1.0-standalone/sample.json" {
+		t.Errorf("Should be able to specify a version")
+	}
+}
+
+func TestDetermineKind(t *testing.T) {
+	_, err := determineKind("sample")
+	if err == nil {
+		t.Errorf("Shouldn't be able to find a kind  when passed a blank string")
+	}
+}


### PR DESCRIPTION
This refactoring moves the display logic out of the kubeval submodule
and into the CLI tool definition. This should make it possible and
hopefully useful to reuse the validator in other tools.

Resolves #10