### PR TITLE
--filename option to override stdin "filename"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,28 @@ $ echo $?
 ```
 
 Alternatively kubeval can also take input via `stdin` which can make using
-it as part of an automated pipeline easier.
+it as part of an automated pipeline easier by removing the need to securely
+manage temporary files.
 
 ```
 $ cat my-invalid-rc.yaml | kubeval
-The document my-invalid-rc.yaml contains an invalid ReplicationController
+The document stdin contains an invalid ReplicationController
 --> spec.replicas: Invalid type. Expected: integer, given: string
 $ echo $?
 1
 ```
 
+To make the output of pipelines more readable, a filename can be injected
+to replace `stdin` in the output:
+
+```
+$ YAML=my-invalid-rc.yaml
+$ cat "$YAML" | kubeval --filename="$YAML"
+The document my-invalid-rc.yaml contains an invalid ReplicationController
+--> spec.replicas: Invalid type. Expected: integer, given: string
+$ echo $?
+1
+```
 
 ## Why?
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,7 @@ var RootCmd = &cobra.Command{
 			for scanner.Scan() {
 				buffer.WriteString(scanner.Text() + "\n")
 			}
-			results, err := kubeval.Validate(buffer.Bytes(), "stdin")
+			results, err := kubeval.Validate(buffer.Bytes(), viper.GetString("filename"))
 			if err != nil {
 				log.Error(err)
 				os.Exit(1)
@@ -111,4 +111,6 @@ func init() {
 	RootCmd.Flags().BoolVarP(&kubeval.Strict, "strict", "", false, "Disallow additional properties not in schema")
 	RootCmd.Flags().BoolVarP(&Version, "version", "", false, "Display the kubeval version information and exit")
 	viper.BindPFlag("schema_location", RootCmd.Flags().Lookup("schema-location"))
+	RootCmd.PersistentFlags().StringP("filename", "f", "stdin", "filename to be displayed when testing manifests read from stdin")
+	viper.BindPFlag("filename", RootCmd.PersistentFlags().Lookup("filename"))
 }


### PR DESCRIPTION
# what is this PR doing?

added a commandline option `--filename` to allow overriding the `stdin` filename displayed when accepting manifests from standard input

# why is it useful/desireable?

I have a loop that kinda looks like the below (pseudo)shell example. A Helm template is rendered to a temporary file (greatly simplified here for brevity) so that the test output displays a filename rather than merely `stdin`.

The `--filename` option provided by this PR allows me to delete all the temporary file handling (`mktemp` etc) and simply pipe the output of `helm template ...` directly to `kubeval`.

```
#!/bin/sh
rc=0
cd $HELM_CHART
for values in envs/*yaml; do
  for template in templates/*yaml; do
    helm template . -x $template -f $values > temporary.yaml
    if ! kubeval temporary.yaml ; then
      rc=1
    fi
    rm -f temporary.yaml
  done
done
exit $rc
```

# behavioural changes

The default behaviour of `kubeval` is not affected by this PR.