### PR TITLE
Remove dependency on libc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,22 +60,22 @@ bin/darwin/amd64:
 build: darwin linux windows
 
 darwin: vendor releases bin/darwin/amd64
-	env GOOS=darwin GOAARCH=amd64 go build -ldflags '$(LDFLAGS)' -v -o $(CURDIR)/bin/darwin/amd64/$(NAME)
+	env CGO_ENABLED=0 GOOS=darwin GOAARCH=amd64 go build -ldflags '$(LDFLAGS)' -v -o $(CURDIR)/bin/darwin/amd64/$(NAME)
 	tar -C bin/darwin/amd64 -cvzf releases/$(NAME)-darwin-amd64.tar.gz $(NAME)
 
 linux: vendor releases bin/linux/amd64
-	env GOOS=linux GOAARCH=amd64 go build -ldflags '$(LDFLAGS)' -v -o $(CURDIR)/bin/linux/amd64/$(NAME)
+	env CGO_ENABLED=0 GOOS=linux GOAARCH=amd64 go build -ldflags '$(LDFLAGS)' -v -o $(CURDIR)/bin/linux/amd64/$(NAME)
 	tar -C bin/linux/amd64 -cvzf releases/$(NAME)-linux-amd64.tar.gz $(NAME)
 
 windows: windows-64 windows-32
 
 windows-64: vendor releases bin/windows/amd64
-	env GOOS=windows GOAARCH=amd64 go build -ldflags '$(LDFLAGS)' -v -o $(CURDIR)/bin/windows/amd64/$(NAME).exe
+	env CGO_ENABLED=0 GOOS=windows GOAARCH=amd64 go build -ldflags '$(LDFLAGS)' -v -o $(CURDIR)/bin/windows/amd64/$(NAME).exe
 	tar -C bin/windows/amd64 -cvzf releases/$(NAME)-windows-amd64.tar.gz $(NAME).exe
 	cd bin/windows/amd64 && zip ../../../releases/$(NAME)-windows-amd64.zip $(NAME).exe
 
 windows-32: vendor releases bin/windows/386
-	env GOOS=windows GOAARCH=386 go build -ldflags '$(LDFLAGS)' -v -o $(CURDIR)/bin/windows/386/$(NAME).exe
+	env CGO_ENABLED=0 GOOS=windows GOAARCH=386 go build -ldflags '$(LDFLAGS)' -v -o $(CURDIR)/bin/windows/386/$(NAME).exe
 	tar -C bin/windows/386 -cvzf releases/$(NAME)-windows-386.tar.gz $(NAME).exe
 	cd bin/windows/386 && zip ../../../releases/$(NAME)-windows-386.zip $(NAME).exe
 


### PR DESCRIPTION
This commit simply adds `CGO_ENABLED=0` to enable a completely static build. This will make the binary run without issue in containers (such as Alpine) and environments that do not bundle `libc` or comparable libraries.