### PR TITLE
empty documents in multi-document yaml files should be valid

### DIFF
--- a/fixtures/multi_valid.yaml
+++ b/fixtures/multi_valid.yaml
@@ -176,3 +176,6 @@ spec:
         ports:
         - containerPort: 80
 ---
+---
+# an empty resource with comments
+---

--- a/kubeval/kubeval.go
+++ b/kubeval/kubeval.go
@@ -128,6 +128,11 @@ func validateResource(data []byte, fileName string) (ValidationResult, error) {
 	}
 
 	body := convertToStringKeys(spec)
+
+	if body == nil {
+		return result, nil
+	}
+
 	documentLoader := gojsonschema.NewGoLoader(body)
 
 	kind, err := determineKind(body)


### PR DESCRIPTION
Using `helm template ...` can result in a multi document yaml with empty documents if some resource templates have been disabled:

```
---
# Source: hadoop/templates/yarn-nm-pvc.yaml

---
```

Such a yaml is valid, as it can successfully be installed via `kubectl apply`. kubeval, however,  reports a `* Missing a kind key` for these documents.

This PR makes kubeval report them as valid.
