### PR TITLE
Add kubeval to $PATH to make CI usage more straightforward

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ RUN make linux
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /go/src/github.com/garethr/kubeval/bin/linux/amd64/kubeval .
+RUN ln -s /kubeval /usr/local/bin/kubeval
 ENTRYPOINT ["/kubeval"]
 CMD ["--help"]

--- a/Dockerfile.offline
+++ b/Dockerfile.offline
@@ -16,5 +16,6 @@ COPY --from=builder /go/src/github.com/garethr/kubeval/bin/linux/amd64/kubeval .
 COPY --from=schemas /kubernetes-json-schema /schemas/kubernetes-json-schema/master
 COPY --from=schemas /openshift-json-schema /schemas/openshift-json-schema/master
 ENV KUBEVAL_SCHEMA_LOCATION=file:///schemas
+RUN ln -s /kubeval /usr/local/bin/kubeval
 ENTRYPOINT ["/kubeval"]
 CMD ["--help"]


### PR DESCRIPTION
This will put a symlink in /usr/local/bin to /kubeval so that it's more intuitive for new users that create CI pipelines don't have to know where kubeval is located in the docker container. 

 Fixes #72