### PR TITLE
Only use stdin if we have no filenames

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,8 +39,8 @@ var RootCmd = &cobra.Command{
 				windowsStdinIssue = true
 			}
 		}
-		// We detect whether we have anything on stdin to process
-		if !windowsStdinIssue && ((stat.Mode() & os.ModeCharDevice) == 0) {
+		// We detect whether we have anything on stdin to process if we have no arguments
+		if len(args) < 1 && !windowsStdinIssue && ((stat.Mode() & os.ModeCharDevice) == 0) {
 			var buffer bytes.Buffer
 			scanner := bufio.NewScanner(os.Stdin)
 			for scanner.Scan() {


### PR DESCRIPTION
Checking if stdin is not a char device has false positives. Particularly in
automated environments (such as CI), stdin will not be a char device.

Fixes https://github.com/garethr/kubeval/issues/36