### PR TITLE
Validate empty files

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -68,11 +68,17 @@
   [ $(expr "$output" : "^Could not open file") -ne 0 ]
 }
 
-@test "Return relevant error for blank file" {
-  run kubeval fixtures/blank.yaml
-  [ "$status" -eq 1 ]
-  [ "$output" = "The document fixtures/blank.yaml appears to be empty" ]
-}
+@test "Pass when parsing a blank config file" {
+   run kubeval fixtures/blank.yaml
+   [ "$status" -eq 0 ]
+   [ "$output" = "The document fixtures/blank.yaml is empty" ]
+ }
+
+ @test "Pass when parsing a blank config file with a comment" {
+   run kubeval fixtures/comment.yaml
+   [ "$status" -eq 0 ]
+   [ "$output" = "The document fixtures/comment.yaml is empty" ]
+ }
 
 @test "Return relevant error for YAML missing kind key" {
   run kubeval fixtures/missing_kind.yaml

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,8 @@ func logResults(results []kubeval.ValidationResult, success bool) bool {
 			for _, desc := range result.Errors {
 				log.Info("--->", desc)
 			}
+		} else if result.Kind == "" {
+			log.Success("The document", result.FileName, "is empty")
 		} else {
 			log.Success("The document", result.FileName, "contains a valid", result.Kind)
 		}

--- a/fixtures/comment.yaml
+++ b/fixtures/comment.yaml
@@ -1,0 +1,3 @@
+---
+# Source: my-chart/templates/my-template.yaml
+

--- a/kubeval/kubeval_test.go
+++ b/kubeval/kubeval_test.go
@@ -38,8 +38,8 @@ func TestValidateValidInputs(t *testing.T) {
 
 func TestValidateInvalidInputs(t *testing.T) {
 	var tests = []string{
-		"missing_kind.json",
-		"missing_kind_value.json",
+		"missing_kind.yaml",
+		"missing_kind_value.yaml",
 	}
 	for _, test := range tests {
 		filePath, _ := filepath.Abs("../fixtures/" + test)

--- a/kubeval/kubeval_test.go
+++ b/kubeval/kubeval_test.go
@@ -9,13 +9,15 @@ import (
 func TestValidateBlankInput(t *testing.T) {
 	blank := []byte("")
 	_, err := Validate(blank, "sample")
-	if err == nil {
-		t.Errorf("Validate should fail when passed a blank string")
+	if err != nil {
+		t.Errorf("Validate should pass when passed a blank string")
 	}
 }
 
 func TestValidateValidInputs(t *testing.T) {
 	var tests = []string{
+		"blank.yaml",
+		"comment.yaml",
 		"valid.yaml",
 		"valid.json",
 		"multi_valid.yaml",
@@ -36,7 +38,6 @@ func TestValidateValidInputs(t *testing.T) {
 
 func TestValidateInvalidInputs(t *testing.T) {
 	var tests = []string{
-		"blank.yaml",
 		"missing_kind.json",
 		"missing_kind_value.json",
 	}
@@ -111,6 +112,6 @@ func TestDetermineSchemaForSchemaLocation(t *testing.T) {
 func TestDetermineKind(t *testing.T) {
 	_, err := determineKind("sample")
 	if err == nil {
-		t.Errorf("Shouldn't be able to find a kind  when passed a blank string")
+		t.Errorf("Shouldn't be able to find a kind when passed a blank string")
 	}
 }


### PR DESCRIPTION
Fixes #78.

This enables kubeval to work with optional kubernetes resources in helm charts. See https://github.com/garethr/kubeval/issues/78#issuecomment-394496798 for an example.

Current error with output
```
The document fixtures/blank.yaml appears to be empty
1 error occurred:

* Missing a kind key
```

New success with output
```
The document fixtures/blank.yaml is empty
The document fixtures/comment.yaml is empty
```
